### PR TITLE
Bump version to 1.0.1 for Chrome Web Store release

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -5,7 +5,7 @@
 
 set -e
 
-VERSION="1.0.0"
+VERSION="1.0.1"
 OUTPUT_FILE="linkre-v${VERSION}.zip"
 
 echo "🔨 Building Linkre Chrome Extension v${VERSION}"

--- a/manifest.json
+++ b/manifest.json
@@ -1,7 +1,7 @@
 {
   "manifest_version": 3,
   "name": "__MSG_extensionName__",
-  "version": "1.0",
+  "version": "1.0.1",
   "description": "__MSG_extensionDescription__",
   "default_locale": "en",
   


### PR DESCRIPTION
- Update manifest.json version from 1.0 to 1.0.1
- Update build.sh VERSION from 1.0.0 to 1.0.1
- Prepare for Chrome Web Store v1.0.1 submission

🤖 Generated with [Claude Code](https://claude.ai/code)